### PR TITLE
Corrects a few dependency versions and removes dead code.

### DIFF
--- a/basic/App.js
+++ b/basic/App.js
@@ -1,15 +1,14 @@
-import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
-import { ApolloProvider } from 'react-apollo'
-import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-client-preset'
-import ListPage from './components/ListPage'
+import React from 'react';
+import { ApolloProvider } from 'react-apollo';
+import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-client-preset';
+import ListPage from './components/ListPage';
 
-const httpLink = new HttpLink({ uri: 'http://localhost:4000' })
+const httpLink = new HttpLink({ uri: 'http://localhost:4000' });
 
 const client = new ApolloClient({
   link: httpLink,
-  cache: new InMemoryCache(),
-})
+  cache: new InMemoryCache()
+});
 
 export default class App extends React.Component {
   render() {
@@ -17,15 +16,6 @@ export default class App extends React.Component {
       <ApolloProvider client={client}>
         <ListPage />
       </ApolloProvider>
-    )
+    );
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-})

--- a/basic/app.json
+++ b/basic/app.json
@@ -1,5 +1,5 @@
 {
   "expo": {
-    "sdkVersion": "22.0.0"
+    "sdkVersion": "24.0.0"
   }
 }

--- a/basic/package.json
+++ b/basic/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "jest-expo": "24.0.0",
+    "flow-bin": "0.49.1",
+    "jest-expo": "^24.0.0",
     "react-native-scripts": "1.8.1",
-    "react-test-renderer": "16.2.0"
+    "react-test-renderer": "16.0.0"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
   "scripts": {
@@ -19,12 +20,12 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "apollo-client-preset": "1.0.5",
-    "expo": "24.0.2",
+    "apollo-client-preset": "^1.0.5",
+    "expo": "^24.0.2",
     "graphql": "0.12.3",
     "graphql-tag": "2.6.1",
-    "react": "16.2.0",
+    "react": "16.0.0",
     "react-apollo": "2.0.4",
-    "react-native": "0.51.0"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz"
   }
 }

--- a/basic/yarn.lock
+++ b/basic/yarn.lock
@@ -224,7 +224,7 @@ apollo-cache@^1.0.2:
   dependencies:
     apollo-utilities "^1.0.3"
 
-apollo-client-preset@1.0.5:
+apollo-client-preset@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/apollo-client-preset/-/apollo-client-preset-1.0.5.tgz#03042ba31926b5ceae70554add385b90a251aa09"
   dependencies:
@@ -2005,7 +2005,7 @@ expect@^21.2.1:
     jest-message-util "^21.2.1"
     jest-regex-util "^21.2.0"
 
-expo@24.0.2:
+expo@^24.0.2:
   version "24.0.2"
   resolved "https://registry.yarnpkg.com/expo/-/expo-24.0.2.tgz#3ff9784afd9efbb8eb739289aa53290ddf31a5a5"
   dependencies:
@@ -2239,6 +2239,10 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flow-bin@0.49.1:
+  version "0.49.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+
 follow-redirects@^1.2.3:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.2.6.tgz#4dcdc7e4ab3dd6765a97ff89c3b4c258117c79bf"
@@ -2324,8 +2328,8 @@ fs-extra@^4.0.2:
     universalify "^0.1.0"
 
 fs-minipass@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.3.tgz#633ee214389dede91c4ec446a34891f964805973"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
   dependencies:
     minipass "^2.2.1"
 
@@ -3139,7 +3143,7 @@ jest-environment-node@^21.2.1:
     jest-mock "^21.2.0"
     jest-util "^21.2.1"
 
-jest-expo@24.0.0:
+jest-expo@^24.0.0:
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-24.0.0.tgz#3a74f8452060768c48c5b254c08c6e53cf7ee847"
   dependencies:
@@ -4697,9 +4701,9 @@ react-native-vector-icons@4.4.2:
     prop-types "^15.5.10"
     yargs "^8.0.2"
 
-react-native@0.51.0:
+"react-native@https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz":
   version "0.51.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.0.tgz#fe25934b3030fd323f3ca1a70f034133465955ed"
+  resolved "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz#aa7b9c20266b844bfc916aa2e4ddb51036d2b83c"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
@@ -4780,14 +4784,6 @@ react-test-renderer@16.0.0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
 
-react-test-renderer@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
-  dependencies:
-    fbjs "^0.8.16"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-timer-mixin@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
@@ -4799,9 +4795,9 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
This PR:

- Updates a few dependencies which were causing errors at runtime.
- Removes the container styles from `App.js` that aren't necessary.
- Adds `flow-bin` to the `devDependencies`, so Flow can be used. The `.flowconfig` is already in the repository.

__Note:__ It might be beneficial to add an npm script (`"flow": "flow"`) to allow users to run Flow quicker. I don't want to get into the whole Flow vs TypeScript discussion, but I'd be open to discussing removing the `.flowconfig` or adding the Flow execution script to this PR, along with any proposed changes.